### PR TITLE
drivers: input: touchcsrenn: Set set_cover_mode permission to 0220

### DIFF
--- a/drivers/input/touchscreen/ft5435/ft5435_ts.c
+++ b/drivers/input/touchscreen/ft5435/ft5435_ts.c
@@ -2738,7 +2738,7 @@ static ssize_t fts_set_cover_mode(struct device *dev,
 	}
 	return ret;
 }
-static DEVICE_ATTR(set_cover_mode, 0664, NULL,
+static DEVICE_ATTR(set_cover_mode, 0220, NULL,
 				fts_set_cover_mode);
 
 #endif


### PR DESCRIPTION
Fixes:

[ 1.140622] Attribute set_cover_mode: read permission without 'show'